### PR TITLE
fix int overflow problem

### DIFF
--- a/rtmp/rtmp_stream_obj.go
+++ b/rtmp/rtmp_stream_obj.go
@@ -191,7 +191,7 @@ func (m *StreamObject) ReadGop(idx *int) *MediaGop {
 
 func (m *StreamObject) WriteFrame(s *MediaFrame) (err error) {
 	m.lock.Lock()
-	if m.idx >= 0xffffffffffffff {
+	if m.idx >= 0x7fffffff {
 		m.idx = 0
 	}
 	s.Idx = m.idx


### PR DESCRIPTION
..\rtmp\rtmp_stream_obj.go:194:11: constant 72057594037927935 overflows int